### PR TITLE
Use a hashset to automatically dedup node neighbours

### DIFF
--- a/src/gfa/graph.rs
+++ b/src/gfa/graph.rs
@@ -28,7 +28,7 @@ impl GFAungraph {
         &self,
         sequence_id: Vec<usize>,
         iterations: i32,
-        mut collect_sequence_names: Vec<NodeIndex>,
+        collect_sequence_names: Vec<NodeIndex>,
         graph_indices: GFAGraphLookups,
     ) -> Result<Vec<usize>> {
         let gfa_graph = &self.0;
@@ -38,28 +38,18 @@ impl GFAungraph {
             sequence_id, iterations
         );
 
-        let mut iteration = 0;
-        loop {
+        let mut collect_sequence_set: HashSet<_> = collect_sequence_names.iter().copied().collect();
+
+        for _ in 0..iterations {
             // collect all the neighbours of all the current node indices
-            for index in collect_sequence_names.clone() {
+            for index in collect_sequence_set.clone() {
                 for c in gfa_graph.neighbors(index) {
                     // could possibly add a conditional in here.
-                    collect_sequence_names.push(c);
+                    collect_sequence_set.insert(c);
                 }
-            }
-            // add sorting and deduping here too
-            // yes otherwise vectors are enormous.
-            collect_sequence_names.sort();
-            collect_sequence_names.dedup();
-
-            iteration += 1;
-            if iteration == iterations {
-                break;
             }
         }
 
-        collect_sequence_names.sort();
-        collect_sequence_names.dedup();
 
         let mut sequences_to_keep = Vec::new();
         // turn node indexes into sequence ID's

--- a/src/gfa/graph.rs
+++ b/src/gfa/graph.rs
@@ -50,15 +50,11 @@ impl GFAungraph {
             }
         }
 
-
-        let mut sequences_to_keep = Vec::new();
         // turn node indexes into sequence ID's
-        for index in collect_sequence_names {
-            let t = graph_indices.node_index_to_seg_id(index)?;
-            sequences_to_keep.push(t);
-        }
-
-        Ok(sequences_to_keep)
+        collect_sequence_set
+            .into_iter()
+            .map(|index| graph_indices.node_index_to_seg_id(index))
+            .collect()
     }
 }
 


### PR DESCRIPTION
### Changes
- use a hashset to avoid sorting and deduping every iteration
- coerce a `Vec` of `Result` into a `Result` of `Vec` for the return value by iterating and collecting over the sequence set